### PR TITLE
Add CI tests for checking tracking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,13 @@ jobs:
 
         - name: Setup Environment
           run: |
-             sudo apt update 
-             sudo apt install bubblewrap python3-bst-external
-             pip3 install --user --pre BuildStream
-             
-        - name: Test
-          run: bst track track.bst
+             mkdir -p ~/.local/bin
+             curl --get https://gitlab.com/BuildStream/buildstream/raw/master/contrib/bst-here > ~/.local/bin/bst-here
+             chmod +x ~/.local/bin/bst-here
+             export PATH="${PATH}:${HOME}/.local/bin"
+
+        - name: Test bst track
+          run: bst-here -j latest-extra track track.bst
 
         - name: "FAILED: Setup tmate session"
           if: ${{ failure() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,10 @@ jobs:
 
         - name: Setup Environment
           run: |
-            sudo apt update
-            sudo apt -y install buildstream bwrap
+             sudo apt update 
+             sudo apt install bubblewrap python3-bst-external
+             pip3 install --user --pre BuildStream
+             
         - name: Test
           run: bst track track.bst
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
         - name: Setup Environment
           run: |
-            sudo apt install update
+            sudo apt update
             sudo apt -y install buildstream
         - name: Test
           run: bst track track.bst

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,17 @@ jobs:
             bst-here -j latest-extra track freedesktop-sdk.bst
             bst-here -j latest-extra track --deps all track.bst
 
+        - name: Test bst build
+          run: |
+            export PATH="${PATH}:${HOME}/.local/bin"
+            bst-here -j latest-extra -o arch x86_64 build iso/image.bst
+            bst-here -j latest-extra -o arch x86_64 checkout --hardlinks iso/image.bst iso
+
+        - uses: actions/upload-artifact@v2
+          with:
+             name: amelia-nightly-iso
+             path: iso/installer.iso
+
         - name: "FAILED: Setup tmate session"
           if: ${{ failure() }}
           uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         - name: Setup Environment
           run: |
             sudo apt update
-            sudo apt -y install buildstream
+            sudo apt -y install buildstream bwrap
         - name: Test
           run: bst track track.bst
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,11 @@ jobs:
              mkdir -p ~/.local/bin
              curl --get https://gitlab.com/BuildStream/buildstream/raw/master/contrib/bst-here > ~/.local/bin/bst-here
              chmod +x ~/.local/bin/bst-here
-             export PATH="${PATH}:${HOME}/.local/bin"
 
         - name: Test bst track
-          run: bst-here -j latest-extra track track.bst
+          run: |
+            export PATH="${PATH}:${HOME}/.local/bin"
+            bst-here -j latest-extra track track.bst
 
         - name: "FAILED: Setup tmate session"
           if: ${{ failure() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,6 @@ jobs:
             bst-here -j latest-extra track freedesktop-sdk.bst
             bst-here -j latest-extra track --deps all track.bst
 
-        - name: Test bst build
-          run: |
-            export PATH="${PATH}:${HOME}/.local/bin"
-            bst-here -j latest-extra -o arch x86_64 build iso/image.bst
-            bst-here -j latest-extra -o arch x86_64 checkout --hardlinks iso/image.bst iso
-
         - uses: actions/upload-artifact@v2
           with:
              name: amelia-nightly-iso

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,8 @@ jobs:
         - name: Test bst track
           run: |
             export PATH="${PATH}:${HOME}/.local/bin"
-            bst-here -j latest-extra track track.bst
+            bst-here -j latest-extra track freedesktop-sdk.bst
+            bst-here -j latest-extra track --deps all track.bst
 
         - name: "FAILED: Setup tmate session"
           if: ${{ failure() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+    test:
+      name: test
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+          with:
+            submodules: recursive
+
+        - name: Setup Environment
+          run: |
+            sudo apt install update
+            sudo apt -y install buildstream
+        - name: Test
+          run: bst track track.bst
+
+        - name: "FAILED: Setup tmate session"
+          if: ${{ failure() }}
+          uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
     track:
       name: test
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       steps:
         - name: Checkout
           uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,9 @@
-name: test
+name: build-debug
 
-on:
-  pull_request:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
-    test:
+    track:
       name: test
       runs-on: ubuntu-latest
       steps:

--- a/elements/track.bst
+++ b/elements/track.bst
@@ -1,0 +1,13 @@
+kind: stack
+description: |
+  Do not build! 
+  This is simply a stack to track all that needs to be tracked properly by Buildstream.
+  As much as possible, only run `bst track` here!
+
+depends:
+  - vm/image.bst
+  - boards/pinebook-pro/image.bst
+  - boards/rock64/image.bst
+  - boards/raspberrypi-4/image.bst
+  - vm/repo-devel.bst
+  - iso/image.bst


### PR DESCRIPTION
This would allow us to test if these packages can be resolved properly. Builds will have to be done on a different CI.